### PR TITLE
upgrade to usb-device v0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usbd-dfu-rt"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Jędrzej Boczar <jedrzej.boczar@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -10,7 +10,7 @@ keywords = ["no-std", "usb-device", "dfu"]
 categories = ["embedded", "no-std"]
 
 [dependencies]
-usb-device = "0.2"
+usb-device = "0.3"
 
 [dev-dependencies]
 # For code in doc-strings

--- a/src/class.rs
+++ b/src/class.rs
@@ -159,7 +159,8 @@ impl<T: DfuRuntimeOps, B: UsbBus> UsbClass<B> for DfuRuntimeClass<T> {
             1,
             USB_CLASS_APPLICATION_SPECIFIC,
             DFU_SUBCLASS_FIRMWARE_UPGRADE,
-            DFU_PROTOCOL_RUNTIME)?;
+            DFU_PROTOCOL_RUNTIME,
+            None)?;
 
         writer.interface(
             self.iface,


### PR DESCRIPTION
This change adds support for version 0.3 of the `usb-device` crate.